### PR TITLE
Add support for Apple silicon

### DIFF
--- a/build-on-mac-ios.sh
+++ b/build-on-mac-ios.sh
@@ -43,6 +43,10 @@ cp $DIR_LIBSODIUM/libsodium-ios/lib/libsodium.a $DIR_DEST/Plugins/iOS/libsodium.
 
 
 git clean -Xdf
+
+# replace osx.sh with modified_osx.sh
+cp $ROOT/modified_osx.sh $DIR_LIBSODIUM/dist-build/osx.sh
+
 ./autogen.sh
 ./dist-build/osx.sh
 mkdir -p $DIR_DEST/Plugins/x64

--- a/modified_osx.sh
+++ b/modified_osx.sh
@@ -1,0 +1,31 @@
+#! /bin/sh
+
+# modified osx.sh for support both arm64 and x86_64
+
+export PREFIX="$(pwd)/libsodium-osx"
+export MACOS_VERSION_MIN=${MACOS_VERSION_MIN-"10.10"}
+
+if [ -z "$LIBSODIUM_FULL_BUILD" ]; then
+  export LIBSODIUM_ENABLE_MINIMAL_FLAG="--enable-minimal"
+else
+  export LIBSODIUM_ENABLE_MINIMAL_FLAG=""
+fi
+
+
+NPROCESSORS=$(getconf NPROCESSORS_ONLN 2>/dev/null || getconf _NPROCESSORS_ONLN 2>/dev/null)
+PROCESSORS=${NPROCESSORS:-3}
+
+mkdir -p $PREFIX || exit 1
+
+export CFLAGS="-arch x86_64 -arch arm64 -mmacosx-version-min=${MACOS_VERSION_MIN} -O2 -g"
+export LDFLAGS="-arch x86_64 -arch arm64 -mmacosx-version-min=${MACOS_VERSION_MIN}"
+
+make distclean > /dev/null
+./configure ${LIBSODIUM_ENABLE_MINIMAL_FLAG} \
+            --prefix="$PREFIX" || exit 1
+
+
+make -j${PROCESSORS} check && make -j${PROCESSORS} install || exit 1
+
+# Cleanup
+make distclean > /dev/null


### PR DESCRIPTION
- build-on-mac-ios.sh will change osx.sh with modified one which support Universal binary(x86_64 + arm64) before build starts.
The script needs to be run on M1/M2 mac or GitHub action with M1 runner.